### PR TITLE
Correct multi conditions

### DIFF
--- a/Editor/Helper/AnimationHelper.DirectBlendTree.cs
+++ b/Editor/Helper/AnimationHelper.DirectBlendTree.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Linq;
 using jp.lilxyzw.lilycalinventory.runtime;
 using UnityEditor.Animations;
@@ -133,87 +132,79 @@ namespace jp.lilxyzw.lilycalinventory
         }
 
         // 複数コンポーネントから操作されるオブジェクト用
-        internal static void AddMultiConditionTree(AnimatorController controller, AnimationClip clipDefault, AnimationClip clipChanged, string[] bools, (string name, int range,(int value, bool isActive)[])[] ints, BlendTree root, bool isActive)
+        internal static void AddMultiConditionTree(AnimatorController controller, AnimationClip clipDefault, AnimationClip clipChanged, (string name, bool isChange)[] bools, (string name, bool[] isChanges)[] ints, BlendTree root)
         {
-            BlendTree parent = root;
-            BlendTree layer = null;
+            AddTree(root);
 
-            // Boolはand条件で処理
-            for(int i = 0; i < bools.Length; i++)
+            void AddTree(BlendTree parent, int depth = 0, int value = 0)
             {
-                layer = new BlendTree
+                var index = depth;
+
+                if(index < bools.Length)
+                {
+                    AddBoolTree(parent, depth, value, bools[index].name, bools[index].isChange);
+                    return;
+                }
+                index -= bools.Length;
+
+                if(index < ints.Length)
+                {
+                    AddIntTree(parent, depth, value, ints[index].name, ints[index].isChanges);
+                    return;
+                }
+                index -= ints.Length;
+
+                parent.AddChild(clipChanged, value);
+            }
+
+            // デフォルトに戻す条件をor、デフォルトから変更する条件をandにする
+            void AddBoolTree(BlendTree parent, int depth, int value, string name, bool isChange)
+            {
+                var layer = new BlendTree
                 {
                     blendType = BlendTreeType.Simple1D,
-                    blendParameter = bools[i],
-                    name = bools[i],
+                    blendParameter = name,
+                    name = name,
                     useAutomaticThresholds = true
                 };
-                if(parent != root)
+                parent.AddChild(layer, value);
+
+                if(!controller.parameters.Any(p => p.name == name))
+                    controller.AddParameter(name, AnimatorControllerParameterType.Float);
+
+                if(!isChange)
                 {
-                    if(isActive)
-                    {
-                        parent.AddChild(layer);
-                        parent.AddChild(clipChanged);
-                    }
-                    else
-                    {
-                        if(parent != root) parent.AddChild(clipDefault);
-                        parent.AddChild(layer);
-                    }
+                    AddTree(layer, depth + 1);
+                    layer.AddChild(clipDefault);
                 }
                 else
                 {
-                    parent.AddChild(layer);
+                    layer.AddChild(clipDefault);
+                    AddTree(layer, depth + 1);
                 }
-                if(!controller.parameters.Any(p => p.name == bools[i]))
-                    controller.AddParameter(bools[i], AnimatorControllerParameterType.Float);
-                parent = layer;
             }
-            var boolEnd = parent;
-            if(!isActive) boolEnd.AddChild(clipDefault);
 
-            // Intもand条件だが、Int内の各数値はor条件
-            var prev = new HashSet<int>{0};
-            int loops = 1;
-            for(int i = 0; i < ints.Length; i++)
+            // デフォルトに戻す条件をor、デフォルトから変更する条件をandにする
+            void AddIntTree(BlendTree parent, int depth, int value, string name, bool[] isChanges)
             {
-                var newInts = new HashSet<int>(ints[i].Item3.Where(p => p.isActive).Select(p => p.value));
-                var inv = ints[i].Item3.Where(p => !p.isActive).Select(p => p.value);
-                if(inv.Count() > 0) newInts.UnionWith(Enumerable.Range(0,ints[i].range).Except(inv));
-                layer = new BlendTree
+                var layer = new BlendTree
                 {
                     blendType = BlendTreeType.Simple1D,
-                    blendParameter = ints[i].name,
-                    name = ints[i].name,
+                    blendParameter = name,
+                    name = name,
                     useAutomaticThresholds = false
                 };
+                parent.AddChild(layer, value);
 
-                if(i > 0) loops = ints[i-1].range;
-                if(parent != root)
+                if(!controller.parameters.Any(p => p.name == name))
+                    controller.AddParameter(name, AnimatorControllerParameterType.Float);
+
+                for(var i = 0; i < isChanges.Length; i++)
                 {
-                    for(int j = 0; j < loops; j++)
-                    {
-                        if(prev.Contains(j)) parent.AddChild(layer, j);
-                        else parent.AddChild(isActive ? clipChanged : clipDefault, j);
-                    }
+                    if(!isChanges[i]) layer.AddChild(clipDefault, i);
+                    else AddTree(layer, depth + 1, i);
                 }
-                else
-                {
-                    parent.AddChild(layer);
-                }
-                prev = newInts;
-
-                if(!controller.parameters.Any(p => p.name == ints[i].name))
-                    controller.AddParameter(ints[i].name, AnimatorControllerParameterType.Float);
-                parent = layer;
             }
-            for(int j = 0; j < ints[ints.Length-1].range; j++)
-            {
-                if(prev.Contains(j)) parent.AddChild(isActive ? clipDefault : clipChanged, j);
-                else parent.AddChild(isActive ? clipChanged : clipDefault, j);
-            }
-
-            if(isActive) boolEnd.AddChild(clipChanged);
         }
     }
 }

--- a/Editor/Helper/AnimationHelper.Layer.cs
+++ b/Editor/Helper/AnimationHelper.Layer.cs
@@ -15,14 +15,14 @@ namespace jp.lilxyzw.lilycalinventory
             var stateDefault = new AnimatorState
             {
                 motion = clipDefault,
-                name = "Off",
+                name = clipDefault.name,
                 writeDefaultValues = hasWriteDefaultsState
             };
 
             var stateChanged = new AnimatorState
             {
                 motion = clipChanged,
-                name = "On",
+                name = clipChanged.name,
                 writeDefaultValues = hasWriteDefaultsState
             };
 
@@ -128,14 +128,14 @@ namespace jp.lilxyzw.lilycalinventory
             var stateDefault = new AnimatorState
             {
                 motion = clipDefault,
-                name = isActive ? "On" : "Off",
+                name = clipDefault.name,
                 writeDefaultValues = hasWriteDefaultsState
             };
 
             var stateChanged = new AnimatorState
             {
                 motion = clipChanged,
-                name = isActive ? "Off" : "On",
+                name = clipChanged.name,
                 writeDefaultValues = hasWriteDefaultsState
             };
 

--- a/Editor/Helper/AnimationHelper.Layer.cs
+++ b/Editor/Helper/AnimationHelper.Layer.cs
@@ -123,7 +123,7 @@ namespace jp.lilxyzw.lilycalinventory
         }
 
         // 複数コンポーネントから操作されるオブジェクト用
-        internal static void AddMultiConditionLayer(AnimatorController controller, bool hasWriteDefaultsState, AnimationClip clipDefault, AnimationClip clipChanged, string name, string[] bools, (string name, int range,(int value, bool isActive)[])[] ints, bool isActive)
+        internal static void AddMultiConditionLayer(AnimatorController controller, bool hasWriteDefaultsState, AnimationClip clipDefault, AnimationClip clipChanged, string name, (string name, bool isChange)[] bools, (string name, bool[] isChanges)[] ints)
         {
             var stateDefault = new AnimatorState
             {
@@ -145,8 +145,7 @@ namespace jp.lilxyzw.lilycalinventory
             stateMachine.AddState(stateChanged, stateMachine.entryPosition + new Vector3(450,0,0));
             stateMachine.defaultState = stateDefault;
 
-            if(!isActive) AddConditions(stateDefault, stateChanged, bools, ints, isActive);
-            else AddConditions(stateChanged, stateDefault, bools, ints, isActive);
+            AddConditions(controller, stateDefault, stateChanged, bools, ints);
 
             var layer = new AnimatorControllerLayer
             {
@@ -159,42 +158,40 @@ namespace jp.lilxyzw.lilycalinventory
             controller.AddLayer(layer);
         }
 
-        private static void AddConditions(AnimatorState stateDefault, AnimatorState stateChanged, string[] bools, (string name, int range,(int value, bool isActive)[])[] ints, bool isActive)
+        private static void AddConditions(AnimatorController controller, AnimatorState stateDefault, AnimatorState stateChanged, (string name, bool isChange)[] bools, (string name, bool[] isChanges)[] ints)
         {
+            var transitionToChanged = stateDefault.AddTransition(stateChanged);
+            transitionToChanged.duration = 0;
 
-            var toChangeds = ints.Select(i => i.Item3.Length).Aggregate((a, b) => a * b);
-            var transitionToChangeds = new AnimatorStateTransition[toChangeds];
-
-            for(int i = 0; i < toChangeds; i++)
+            // デフォルトに戻す条件をor、デフォルトから変更する条件をandにする
+            foreach(var (name, isChange) in bools)
             {
-                transitionToChangeds[i] = stateDefault.AddTransition(stateChanged);
-                transitionToChangeds[i].duration = 0;
-            }
-
-            // Boolはand条件で処理
-            foreach(var b in bools)
-            {
-                foreach(var transitionToChanged in transitionToChangeds)
-                    transitionToChanged.AddCondition(isActive ? AnimatorConditionMode.IfNot : AnimatorConditionMode.If, 0, b);
-
                 var transitionToDefault = stateChanged.AddTransition(stateDefault);
                 transitionToDefault.duration = 0;
-                transitionToDefault.AddCondition(isActive ? AnimatorConditionMode.If : AnimatorConditionMode.IfNot, 0, b);
+                transitionToDefault.AddCondition(!isChange ? AnimatorConditionMode.If : AnimatorConditionMode.IfNot, 0, name);
+
+                transitionToChanged.AddCondition(!isChange ? AnimatorConditionMode.IfNot : AnimatorConditionMode.If, 0, name);
+
+                if(!controller.parameters.Any(p => p.name == name))
+                    controller.AddParameter(name, AnimatorControllerParameterType.Bool);
             }
 
-            // Intもand条件だが、Int内の各数値はor条件
-            int offset = 1;
-            foreach(var b in ints)
+            // デフォルトに戻す条件をor、デフォルトから変更する条件をandにする
+            foreach(var (name, isChanges) in ints)
             {
-                for(int i = 0; i < b.Item3.Length; i++)
-                    transitionToChangeds[i*offset].AddCondition(!b.Item3[i].isActive ? AnimatorConditionMode.NotEqual : AnimatorConditionMode.Equals, b.Item3[i].value, b.name);
+                // デフォルトから変更する値を使うと両方の遷移でandとorの組み合わせを考えることになるが、
+                // デフォルトに戻す値を使うと一方の遷移はorだけ、もう一方の遷移はandだけ考えればよくなる
+                foreach(var value in Enumerable.Range(0, isChanges.Length).Where(i => !isChanges[i]))
+                {
+                    var transitionToDefault = stateChanged.AddTransition(stateDefault);
+                    transitionToDefault.duration = 0;
+                    transitionToDefault.AddCondition(AnimatorConditionMode.Equals, value, name);
 
-                offset *= b.Item3.Length;
+                    transitionToChanged.AddCondition(AnimatorConditionMode.NotEqual, value, name);
+                }
 
-                var transitionToDefault = stateChanged.AddTransition(stateDefault);
-                transitionToDefault.duration = 0;
-                foreach(var c in b.Item3)
-                    transitionToDefault.AddCondition(!c.isActive ? AnimatorConditionMode.Equals : AnimatorConditionMode.NotEqual, c.value, b.name);
+                if(!controller.parameters.Any(p => p.name == name))
+                    controller.AddParameter(name, AnimatorControllerParameterType.Int);
             }
         }
     }

--- a/Editor/Helper/AnimationHelper.ParametersPerMenu.cs
+++ b/Editor/Helper/AnimationHelper.ParametersPerMenu.cs
@@ -264,18 +264,18 @@ namespace jp.lilxyzw.lilycalinventory
             return parameter;
         }
 
-        internal static void GatherConditions(this ItemToggler[] itemTogglers, Dictionary<GameObject, HashSet<(string name, bool isChange)>> dic)
+        internal static void GatherConditions(this ItemToggler[] itemTogglers, Dictionary<GameObject, HashSet<(string name, bool toActive)>> dic)
         {
             foreach(var itemToggler in itemTogglers)
                 foreach(var toggler in itemToggler.parameter.objects)
-                    dic.GetOrAdd(toggler.obj).Add((itemToggler.menuName, toggler.value != toggler.obj.activeSelf));
+                    dic.GetOrAdd(toggler.obj).Add((itemToggler.menuName, toggler.value));
         }
 
-        internal static void GatherConditions(this CostumeChanger[] costumeChangers, Dictionary<GameObject, HashSet<(string name, bool[] isChanges)>> dic)
+        internal static void GatherConditions(this CostumeChanger[] costumeChangers, Dictionary<GameObject, HashSet<(string name, bool[] toActives)>> dic)
         {
             foreach(var costumeChanger in costumeChangers)
                 foreach(var obj in costumeChanger.costumes.SelectMany(c => c.parametersPerMenu.objects).Select(o => o.obj).Distinct())
-                    dic.GetOrAdd(obj).Add((costumeChanger.menuName, costumeChanger.costumes.Select(c => (c.parametersPerMenu.objects.SingleOrDefault(x => x.obj == obj)?.value ?? obj.activeSelf) != obj.activeSelf).ToArray()));
+                    dic.GetOrAdd(obj).Add((costumeChanger.menuName, costumeChanger.costumes.Select(c => c.parametersPerMenu.objects.SingleOrDefault(x => x.obj == obj)?.value ?? obj.activeSelf).ToArray()));
         }
 
         private static HashSet<TValue> GetOrAdd<TKey,TValue>(this Dictionary<TKey,HashSet<TValue>> dic, TKey key)

--- a/Editor/Helper/AnimationHelper.ParametersPerMenu.cs
+++ b/Editor/Helper/AnimationHelper.ParametersPerMenu.cs
@@ -14,18 +14,18 @@ namespace jp.lilxyzw.lilycalinventory
 
     internal static partial class AnimationHelper
     {
-        internal static (InternalClip,InternalClip) CreateClip(this ParametersPerMenu parameter, GameObject gameObject, string name)
+        internal static (InternalClip clipDefault, InternalClip clipChanged) CreateClip(this ParametersPerMenu parameter, GameObject gameObject, string name)
         {
-            var clipOff = new InternalClip();
-            var clipOn = new InternalClip();
-            clipOff.name = $"{name}_Off";
-            clipOn.name = $"{name}_On";
+            var clipDefault = new InternalClip();
+            var clipChanged = new InternalClip();
+            clipDefault.name = $"{name}_Default";
+            clipChanged.name = $"{name}_Changed";
 
             foreach(var toggler in parameter.objects)
             {
                 if(!toggler.obj) continue;
-                toggler.ToClipDefault(clipOff);
-                toggler.ToClip(clipOn);
+                toggler.ToClipDefault(clipDefault);
+                toggler.ToClip(clipChanged);
             }
 
             foreach(var modifier in parameter.blendShapeModifiers)
@@ -39,8 +39,8 @@ namespace jp.lilxyzw.lilycalinventory
                         foreach(var namevalue in modifier.blendShapeNameValues)
                         {
                             if(renderer.sharedMesh.GetBlendShapeIndex(namevalue.name) == -1) continue;
-                            namevalue.ToClipDefault(clipOff, renderer);
-                            namevalue.ToClip(clipOn, renderer);
+                            namevalue.ToClipDefault(clipDefault, renderer);
+                            namevalue.ToClip(clipChanged, renderer);
                         }
                     }
                     continue;
@@ -48,16 +48,16 @@ namespace jp.lilxyzw.lilycalinventory
                 if(!modifier.skinnedMeshRenderer) continue;
                 foreach(var namevalue in modifier.blendShapeNameValues)
                 {
-                    namevalue.ToClipDefault(clipOff, modifier.skinnedMeshRenderer);
-                    namevalue.ToClip(clipOn, modifier.skinnedMeshRenderer);
+                    namevalue.ToClipDefault(clipDefault, modifier.skinnedMeshRenderer);
+                    namevalue.ToClip(clipChanged, modifier.skinnedMeshRenderer);
                 }
             }
 
             foreach(var replacer in parameter.materialReplacers)
             {
                 if(!replacer.renderer) continue;
-                replacer.ToClipDefault(clipOff);
-                replacer.ToClip(clipOn);
+                replacer.ToClipDefault(clipDefault);
+                replacer.ToClip(clipChanged);
             }
 
             foreach(var modifier in parameter.materialPropertyModifiers)
@@ -65,19 +65,19 @@ namespace jp.lilxyzw.lilycalinventory
                 if(modifier.renderers.Length == 0)
                     modifier.renderers = gameObject.GetComponentsInChildren<Renderer>(true).ToArray();
 
-                modifier.ToClipDefault(clipOff);
-                modifier.ToClip(clipOn, clipOff);
+                modifier.ToClipDefault(clipDefault);
+                modifier.ToClip(clipChanged, clipDefault);
             }
 
             foreach(var clip in parameter.clips)
             {
-                clipOff.AddDefault(clip, gameObject);
-                clipOn.Add(clip);
+                clipDefault.AddDefault(clip, gameObject);
+                clipChanged.Add(clip);
             }
-            return (clipOff, clipOn);
+            return (clipDefault, clipChanged);
         }
 
-        internal static (InternalClip,InternalClip) CreateClip(this ParametersPerMenu parameter, BuildContext ctx, string name)
+        internal static (InternalClip clipDefault, InternalClip clipChanged) CreateClip(this ParametersPerMenu parameter, BuildContext ctx, string name)
         {
             return parameter.CreateClip(ctx.AvatarRootObject, name);
         }

--- a/Editor/Helper/AnimationHelper.ParametersPerMenu.cs
+++ b/Editor/Helper/AnimationHelper.ParametersPerMenu.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
@@ -265,44 +264,23 @@ namespace jp.lilxyzw.lilycalinventory
             return parameter;
         }
 
-        // TODO: Support other than toggler
-        internal static void GatherConditions(this ItemToggler[] itemTogglers, Dictionary<GameObject, HashSet<string>> dic)
+        internal static void GatherConditions(this ItemToggler[] itemTogglers, Dictionary<GameObject, HashSet<(string name, bool isChange)>> dic)
         {
             foreach(var itemToggler in itemTogglers)
                 foreach(var toggler in itemToggler.parameter.objects)
-                    dic.GetOrAdd(toggler.obj).Add(itemToggler.menuName);
+                    dic.GetOrAdd(toggler.obj).Add((itemToggler.menuName, toggler.value != toggler.obj.activeSelf));
         }
 
-        internal static void GatherConditions(this CostumeChanger[] costumeChangers, Dictionary<GameObject, Dictionary<string, (int,HashSet<(int,bool)>)>> dic)
+        internal static void GatherConditions(this CostumeChanger[] costumeChangers, Dictionary<GameObject, HashSet<(string name, bool[] isChanges)>> dic)
         {
             foreach(var costumeChanger in costumeChangers)
-            {
-                for(int i = 0; i < costumeChanger.costumes.Length; i++)
-                {
-                    var parameter = costumeChanger.costumes[i].parametersPerMenu;
-                    foreach(var toggler in parameter.objects)
-                    {
-                        dic.GetOrAdd(toggler.obj).GetOrAdd(costumeChanger.menuName, costumeChanger.costumes.Length).Item2.Add((i, toggler.value));
-                    }
-                }
-            }
-        }
-
-        private static Dictionary<TValue,TValue2> GetOrAdd<TKey,TValue,TValue2>(this Dictionary<TKey,Dictionary<TValue,TValue2>> dic, TKey key)
-        {
-            if(!dic.ContainsKey(key)) dic[key] = new Dictionary<TValue,TValue2>();
-            return dic[key];
+                foreach(var obj in costumeChanger.costumes.SelectMany(c => c.parametersPerMenu.objects).Select(o => o.obj).Distinct())
+                    dic.GetOrAdd(obj).Add((costumeChanger.menuName, costumeChanger.costumes.Select(c => (c.parametersPerMenu.objects.SingleOrDefault(x => x.obj == obj)?.value ?? obj.activeSelf) != obj.activeSelf).ToArray()));
         }
 
         private static HashSet<TValue> GetOrAdd<TKey,TValue>(this Dictionary<TKey,HashSet<TValue>> dic, TKey key)
         {
             if(!dic.ContainsKey(key)) dic[key] = new HashSet<TValue>();
-            return dic[key];
-        }
-
-        private static (int,HashSet<TValue>) GetOrAdd<TKey,TValue>(this Dictionary<TKey,(int,HashSet<TValue>)> dic, TKey key, int value)
-        {
-            if(!dic.ContainsKey(key)) dic[key] = (value,new HashSet<TValue>());
             return dic[key];
         }
     }

--- a/Editor/Processor/Modifier.CostumeChanger.cs
+++ b/Editor/Processor/Modifier.CostumeChanger.cs
@@ -33,9 +33,7 @@ namespace jp.lilxyzw.lilycalinventory
                 for(int i = 0; i < changer.costumes.Length; i++)
                 {
                     var costume = changer.costumes[i];
-                    var clip2 = costume.parametersPerMenu.CreateClip(ctx, costume.menuName);
-                    clipDefaults[i] = clip2.Item1;
-                    clipChangeds[i] = clip2.Item2;
+                    (clipDefaults[i], clipChangeds[i]) = costume.parametersPerMenu.CreateClip(ctx, costume.menuName);
                 }
 
                 // 同期事故防止のためにオブジェクトのオンオフ状況をコンポーネントの設定に合わせる

--- a/Editor/Processor/Modifier.ItemToggler.cs
+++ b/Editor/Processor/Modifier.ItemToggler.cs
@@ -1,7 +1,5 @@
-using System.Linq;
 using UnityEditor;
 using UnityEditor.Animations;
-using UnityEngine;
 
 #if LIL_NDMF
 using nadena.dev.ndmf;
@@ -37,12 +35,6 @@ namespace jp.lilxyzw.lilycalinventory
                     // AnimatorControllerに追加
                     if(root) AnimationHelper.AddItemTogglerTree(controller, clipDefault, clipChanged, name, root);
                     else AnimationHelper.AddItemTogglerLayer(controller, hasWriteDefaultsState, clipDefault, clipChanged, name);
-                }
-                else
-                {
-                    // 全オブジェクトが複数条件で操作される場合はパラメーターだけ追加
-                    if(!controller.parameters.Any(p => p.name == name))
-                        controller.AddParameter(name, AnimatorControllerParameterType.Float);
                 }
 
                 #if LIL_VRCSDK3A

--- a/Editor/Processor/Modifier.ItemToggler.cs
+++ b/Editor/Processor/Modifier.ItemToggler.cs
@@ -30,13 +30,13 @@ namespace jp.lilxyzw.lilycalinventory
                 {
                     // コンポーネントの設定値とprefab初期値を取得したAnimationClipを作成
                     var clips = toggler.parameter.CreateClip(ctx, name);
-                    var clips2 = (clips.Item1.ToClip(), clips.Item2.ToClip());
-                    AssetDatabase.AddObjectToAsset(clips2.Item1, ctx.AssetContainer);
-                    AssetDatabase.AddObjectToAsset(clips2.Item2, ctx.AssetContainer);
+                    var (clipDefault, clipChanged) = (clips.clipDefault.ToClip(), clips.clipChanged.ToClip());
+                    AssetDatabase.AddObjectToAsset(clipDefault, ctx.AssetContainer);
+                    AssetDatabase.AddObjectToAsset(clipChanged, ctx.AssetContainer);
 
                     // AnimatorControllerに追加
-                    if(root) AnimationHelper.AddItemTogglerTree(controller, clips2.Item1, clips2.Item2, name, root);
-                    else AnimationHelper.AddItemTogglerLayer(controller, hasWriteDefaultsState, clips2.Item1, clips2.Item2, name);
+                    if(root) AnimationHelper.AddItemTogglerTree(controller, clipDefault, clipChanged, name, root);
+                    else AnimationHelper.AddItemTogglerLayer(controller, hasWriteDefaultsState, clipDefault, clipChanged, name);
                 }
                 else
                 {

--- a/Editor/Processor/Modifier.ResolveMultiConditions.cs
+++ b/Editor/Processor/Modifier.ResolveMultiConditions.cs
@@ -17,8 +17,8 @@ namespace jp.lilxyzw.lilycalinventory
         internal static void ResolveMultiConditions(BuildContext ctx, AnimatorController controller, bool hasWriteDefaultsState, ItemToggler[] togglers, CostumeChanger[] costumeChangers, BlendTree root)
         {
             // 複数コンポーネントから操作されるオブジェクトを見つける
-            var toggleBools = new Dictionary<GameObject, HashSet<(string name, bool isChange)>>();
-            var toggleInts = new Dictionary<GameObject, HashSet<(string name, bool[] isChanges)>>();
+            var toggleBools = new Dictionary<GameObject, HashSet<(string name, bool toActive)>>();
+            var toggleInts = new Dictionary<GameObject, HashSet<(string name, bool[] toActives)>>();
             togglers.GatherConditions(toggleBools);
             costumeChangers.GatherConditions(toggleInts);
             var multiConditionObjects = toggleBools.Keys.Concat(toggleInts.Keys)
@@ -34,12 +34,13 @@ namespace jp.lilxyzw.lilycalinventory
                     t.parametersPerMenu.objects = t.parametersPerMenu.objects.Where(o => !multiConditionObjects.Contains(o.obj)).ToArray();
 
             // 同一条件のオブジェクトをまとめる
-            var conditionAndObjects = new Dictionary<((string name, bool isChange)[] bools, (string name, bool[] isChanges)[] ints), List<GameObject>>();
+            var conditionAndObjects = new Dictionary<((string name, bool toActive)[] bools, (string name, bool[] toActives)[] ints, bool isActive), List<GameObject>>();
             foreach(var o in multiConditionObjects)
             {
-                var bools = toggleBools.ContainsKey(o) ? toggleBools[o].OrderBy(b => b.name).ToArray() : new (string name, bool isChange)[0];
-                var ints = toggleInts.ContainsKey(o) ? toggleInts[o].OrderBy(i => i.name).ToArray() : new (string name, bool[] isChanges)[0];
-                var key = conditionAndObjects.Keys.Where(x => IsSameConditions(x, (bools, ints))).DefaultIfEmpty((bools, ints)).Single();
+                var bools = toggleBools.ContainsKey(o) ? toggleBools[o].OrderBy(b => b.name).ToArray() : new (string name, bool toActive)[0];
+                var ints = toggleInts.ContainsKey(o) ? toggleInts[o].OrderBy(i => i.name).ToArray() : new (string name, bool[] toActives)[0];
+                var isActive = o.activeSelf;
+                var key = conditionAndObjects.Keys.Where(x => IsSameConditions(x, (bools, ints, isActive))).DefaultIfEmpty((bools, ints, isActive)).Single();
                 if(conditionAndObjects.ContainsKey(key))
                 {
                     conditionAndObjects[key].Add(o);
@@ -55,6 +56,7 @@ namespace jp.lilxyzw.lilycalinventory
             {
                 var bools = c.Key.bools;
                 var ints = c.Key.ints;
+                var isActive = c.Key.isActive;
 
                 var name = c.Value.ElementAt(0).name;
                 var clips = (clipDefault: new InternalClip(), clipChanged: new InternalClip());
@@ -65,7 +67,7 @@ namespace jp.lilxyzw.lilycalinventory
                     var toggler = new ObjectToggler
                     {
                         obj = o,
-                        value = !o.activeSelf
+                        value = !isActive
                     };
                     toggler.ToClipDefault(clips.clipDefault);
                     toggler.ToClip(clips.clipChanged);
@@ -75,20 +77,20 @@ namespace jp.lilxyzw.lilycalinventory
 
                 AssetDatabase.AddObjectToAsset(clipDefault, ctx.AssetContainer);
                 AssetDatabase.AddObjectToAsset(clipChanged, ctx.AssetContainer);
-                if(root) AnimationHelper.AddMultiConditionTree(controller, clipDefault, clipChanged, bools, ints, root);
-                else AnimationHelper.AddMultiConditionLayer(controller, hasWriteDefaultsState, clipDefault, clipChanged, name, bools, ints);
+                if(root) AnimationHelper.AddMultiConditionTree(controller, clipDefault, clipChanged, bools, ints, root, isActive);
+                else AnimationHelper.AddMultiConditionLayer(controller, hasWriteDefaultsState, clipDefault, clipChanged, name, bools, ints, isActive);
             }
         }
 
-        private static bool IsSameConditions(((string name, bool isChange)[] bools, (string name, bool[] isChanges)[] ints) a, ((string name, bool isChange)[] bools, (string name, bool[] isChanges)[] ints) b)
+        private static bool IsSameConditions(((string name, bool toActive)[] bools, (string name, bool[] toActives)[] ints, bool isActive) a, ((string name, bool toActive)[] bools, (string name, bool[] toActives)[] ints, bool isActive) b)
         {
             if(!a.bools.SequenceEqual(b.bools)) return false;
             if(!a.ints.Select(k => k.name).SequenceEqual(b.ints.Select(k => k.name))) return false;
             for(int i = 0; i < a.ints.Length; i++)
             {
-                if(!a.ints[i].isChanges.SequenceEqual(b.ints[i].isChanges)) return false;
+                if(!a.ints[i].toActives.SequenceEqual(b.ints[i].toActives)) return false;
             }
-            return true;
+            return a.isActive == b.isActive;
         }
     }
 }

--- a/Editor/Processor/Modifier.ResolveMultiConditions.cs
+++ b/Editor/Processor/Modifier.ResolveMultiConditions.cs
@@ -65,10 +65,9 @@ namespace jp.lilxyzw.lilycalinventory
                 var isActive = c.Key.isActive;
 
                 var name = c.Value.ElementAt(0).name;
-                var clipOff = new InternalClip();
-                var clipOn = new InternalClip();
-                clipOff.name = $"{name}_Off";
-                clipOn.name = $"{name}_On";
+                var clips = (clipDefault: new InternalClip(), clipChanged: new InternalClip());
+                clips.clipDefault.name = $"{name}_Default";
+                clips.clipChanged.name = $"{name}_Changed";
                 foreach(var o in c.Value)
                 {
                     var toggler = new ObjectToggler
@@ -76,16 +75,16 @@ namespace jp.lilxyzw.lilycalinventory
                         obj = o,
                         value = !isActive
                     };
-                    toggler.ToClipDefault(clipOff);
-                    toggler.ToClip(clipOn);
+                    toggler.ToClipDefault(clips.clipDefault);
+                    toggler.ToClip(clips.clipChanged);
                 }
-                var clipOff2 = clipOff.ToClip();
-                var clipOn2 = clipOn.ToClip();
+                var clipDefault = clips.clipDefault.ToClip();
+                var clipChanged = clips.clipChanged.ToClip();
 
-                AssetDatabase.AddObjectToAsset(clipOff2, ctx.AssetContainer);
-                AssetDatabase.AddObjectToAsset(clipOn2, ctx.AssetContainer);
-                if(root) AnimationHelper.AddMultiConditionTree(controller, clipOff2, clipOn2, bools, ints, root, isActive);
-                else AnimationHelper.AddMultiConditionLayer(controller, hasWriteDefaultsState, clipOff2, clipOn2, name, bools, ints, isActive);
+                AssetDatabase.AddObjectToAsset(clipDefault, ctx.AssetContainer);
+                AssetDatabase.AddObjectToAsset(clipChanged, ctx.AssetContainer);
+                if(root) AnimationHelper.AddMultiConditionTree(controller, clipDefault, clipChanged, bools, ints, root, isActive);
+                else AnimationHelper.AddMultiConditionLayer(controller, hasWriteDefaultsState, clipDefault, clipChanged, name, bools, ints, isActive);
             }
         }
 


### PR DESCRIPTION
Fixes #67 ですが、正しい仕様が分からず自信もないのでひとまず思うように修正を入れてみましたという状態です。

あるオブジェクトのアクティブ/非アクティブについて、

- デフォルト状態から変更しようとする ItemToggler が全て ON
- デフォルト状態に戻そうとする ItemToggler が全て OFF
- デフォルト状態から変更しようとするコスチュームを持った CostumeChanger 全てにおいて、デフォルト状態から変更しようとするコスチュームが選択されている
- デフォルト状態に戻そうとするコスチュームのみを持った CostumeChanger が存在しない

をすべて満たすとき、デフォルト状態から変更し、そうでなければデフォルト状態に戻すような動作を想定しています。
考慮漏れはあるかもしれません。多分あります。

---

例として、デフォルトでアクティブなオブジェクトに対して

- ItemToggler_A: `オンにする`
- ItemToggler_B: `オフにする`
- CostumeChanger_A
  - 0: 指定なし
  - 1: 指定なし
  - 2: `オフにする`
  - 3: `オフにする`
- CostumeChanger_B
  - 0: 指定なし
  - 1: 指定なし
  - 2: `オフにする`
  - 3: `オフにする`

という組み方をしたとき、

- ItemToggler_A = False
- ItemToggler_B = True
- CostumeChanger_A = 2 or 3
- CostumeChanger_B = 2 or 3

をすべて満たすとき、非アクティブになる想定です。