### PR TITLE
Fix version check issues

### DIFF
--- a/Editor/VersionChecker.cs
+++ b/Editor/VersionChecker.cs
@@ -20,7 +20,7 @@ namespace jp.lilxyzw.lilycalinventory
         {
             if(label == null)
             {
-                if(instance.latest > instance.current)
+                if (instance.latest != null && instance.current != null && instance.latest > instance.current)
                 {
                     // 更新がある場合は最新バージョンも合わせて表示、赤字で強調
                     label = new GUIContent($"{ConstantValues.TOOL_NAME} {instance.current} => {instance.latest}");

--- a/Editor/VersionChecker.cs
+++ b/Editor/VersionChecker.cs
@@ -91,6 +91,10 @@ namespace jp.lilxyzw.lilycalinventory
                     throw e;
                 }
             }
+            else
+            {
+                instance.latest = new SemVerParser("0.0.0");
+            }
         }
 
         private class PackageInfo


### PR DESCRIPTION
Fix editor unable to display due to version check network issues.
(When most users in Chinese Mainland use it, if the vpn is not enabled, it is easy to cause the editor of lilycalInventory to fail to display correctly.)