### PR TITLE
fix: error when parameters is null

### DIFF
--- a/Editor/Processor/Processor.cs
+++ b/Editor/Processor/Processor.cs
@@ -4,6 +4,10 @@ using UnityEditor;
 using UnityEditor.Animations;
 using UnityEngine;
 
+#if LIL_VRCSDK3A
+using VRC.SDK3.Avatars.ScriptableObjects;
+#endif
+
 #if LIL_NDMF
 using nadena.dev.ndmf;
 #endif
@@ -196,6 +200,11 @@ namespace jp.lilxyzw.lilycalinventory
                     controller = new AnimatorController();
                     AssetDatabase.AddObjectToAsset(controller, ctx.AssetContainer);
                 }
+                #endif
+                
+                #if LIL_VRCSDK3A
+                if (ctx.AvatarDescriptor.expressionParameters.parameters == null)
+                    ctx.AvatarDescriptor.expressionParameters.parameters = new VRCExpressionParameters.Parameter[0];
                 #endif
 
                 var hasWriteDefaultsState = controller.HasWriteDefaultsState();

--- a/Editor/VersionChecker.cs
+++ b/Editor/VersionChecker.cs
@@ -20,7 +20,7 @@ namespace jp.lilxyzw.lilycalinventory
         {
             if(label == null)
             {
-                if(instance.latest > instance.current)
+                if (instance.latest != null && instance.current != null && instance.latest > instance.current)
                 {
                     // 更新がある場合は最新バージョンも合わせて表示、赤字で強調
                     label = new GUIContent($"{ConstantValues.TOOL_NAME} {instance.current} => {instance.latest}");
@@ -90,6 +90,10 @@ namespace jp.lilxyzw.lilycalinventory
                     instance.latest = new SemVerParser("0.0.0");
                     throw e;
                 }
+            }
+            else
+            {
+                instance.latest = new SemVerParser("0.0.0");
             }
         }
 


### PR DESCRIPTION
`VRCExpressionParameters` の `parameters` が `null` のときにエラーが発生するのを修正しました

たとえばこの事象は Prefabulous の Blank Expressions Menu and Parameters を使用している場合に発生します
https://docs.hai-vr.dev/docs/products/prefabulous/vrchat/blank-expressions-menu-and-parameters