### PR TITLE
feat: make original materials clickable in Material Replacer

### DIFF
--- a/Editor/CustomEditor/ParametersPerMenuEditor.cs
+++ b/Editor/CustomEditor/ParametersPerMenuEditor.cs
@@ -301,7 +301,7 @@ namespace jp.lilxyzw.lilycalinventory
 
             position.Indent();
             EditorGUI.LabelField(position.NewLine(), Localization.G("inspector.replaceTo"));
-            position = GUIHelper.SimpleList(replaceTo, position.NewLine(), materials.Select(m => m.TryGetName()).ToArray());
+            position = GUIHelper.SimpleList(replaceTo, position.NewLine(), materials);
         }
 
         public override float GetPropertyHeight(SerializedProperty property, GUIContent label)

--- a/Editor/Helper/GUIHelper.SimpleList.cs
+++ b/Editor/Helper/GUIHelper.SimpleList.cs
@@ -6,15 +6,28 @@ namespace jp.lilxyzw.lilycalinventory
     internal static partial class GUIHelper
     {
         // リストのかわりにプロパティを並べて表示するだけのシンプルなもの
-        internal static Rect SimpleList(SerializedProperty prop, Rect position, string[] labels)
+        internal static Rect SimpleList(SerializedProperty prop, Rect position, Material[] originalMaterials)
         {
             using var endProperty = prop.GetEndProperty();
             prop.NextVisible(true);
             position.Back();
             int i = 0;
-            while(prop.NextVisible(false) && !SerializedProperty.EqualContents(prop, endProperty))
+            while (prop.NextVisible(false) && !SerializedProperty.EqualContents(prop, endProperty))
             {
-                EditorGUI.PropertyField(position.NewLine(), prop, new GUIContent(labels[i++]));
+                var rect = position.NewLine();
+
+                var materialRect = rect;
+                materialRect.width = rect.width * 0.5f - 2;
+                EditorGUI.BeginDisabledGroup(true);
+                EditorGUI.ObjectField(materialRect, originalMaterials[i], typeof(Material), false);
+                EditorGUI.EndDisabledGroup();
+
+                var replaceRect = rect;
+                replaceRect.x += materialRect.width + 4;
+                replaceRect.width = rect.width * 0.5f - 2;
+                EditorGUI.PropertyField(replaceRect, prop, GUIContent.none);
+
+                i++;
             }
             return position;
         }

--- a/Editor/Helper/PreviewHelper.cs
+++ b/Editor/Helper/PreviewHelper.cs
@@ -68,10 +68,26 @@ namespace jp.lilxyzw.lilycalinventory
         private void StartPreview(AutoDresser dresser)
         {
             var gameObject = target.gameObject.GetAvatarRoot().gameObject;
-
             var dressers = gameObject.GetComponentsInChildren<AutoDresser>(true).Where(c => c.enabled).ToArray();
-            var parameters = dressers.DresserToCostumes(out Transform avatarRoot, null, new Preset[]{}, dresser).Select(c => c.parametersPerMenu).ToArray();
-
+            
+            // create a parameter list to disable other dressers
+            var disableParameters = new ParametersPerMenu();
+            disableParameters.objects = dressers.Where(d => d != dresser)  
+                .Select(d => d.gameObject)  
+                .Select(go => new ObjectToggler { obj = go, value = false })  
+                .ToArray();
+            
+            // get the parameters of the current dresser
+            var parameters = new[] { dresser }.DresserToCostumes(out Transform avatarRoot, null, new Preset[]{}, dresser)
+                .Select(c => c.parametersPerMenu)
+                .ToArray();
+            
+            // merge parameters: disable other dressers first, then apply the current dresser's effect
+            if(parameters.Length > 0)
+            {
+                parameters[0].objects = parameters[0].objects.Union(disableParameters.objects).ToArray();
+            }
+            
             StartPreview(parameters, 0);
         }
 

--- a/Editor/VersionChecker.cs
+++ b/Editor/VersionChecker.cs
@@ -20,7 +20,7 @@ namespace jp.lilxyzw.lilycalinventory
         {
             if(label == null)
             {
-                if(instance.latest > instance.current)
+                if (instance.latest != null && instance.current != null && instance.latest > instance.current)
                 {
                     // 更新がある場合は最新バージョンも合わせて表示、赤字で強調
                     label = new GUIContent($"{ConstantValues.TOOL_NAME} {instance.current} => {instance.latest}");
@@ -90,6 +90,10 @@ namespace jp.lilxyzw.lilycalinventory
                     instance.latest = new SemVerParser("0.0.0");
                     throw e;
                 }
+            }
+            else
+            {
+                instance.latest = new SemVerParser("0.0.0");
             }
         }
 


### PR DESCRIPTION
Description:
Changed material display from text to object fields in Material Replacer so users can easily locate original materials in Project window by clicking them.

Before:
![387fd140780e5107f09259ac3c06ad71](https://github.com/user-attachments/assets/e7f959b5-071c-48b3-9038-84c8456b1560)

After:
![222b42cf7e70a815ab93cf1eb4a64741](https://github.com/user-attachments/assets/d15395fc-da90-44bc-bbd8-8373f9b48881)
