### PR TITLE
Fix AutoDresser preview parameter application

### DIFF
--- a/Editor/Helper/PreviewHelper.cs
+++ b/Editor/Helper/PreviewHelper.cs
@@ -68,10 +68,26 @@ namespace jp.lilxyzw.lilycalinventory
         private void StartPreview(AutoDresser dresser)
         {
             var gameObject = target.gameObject.GetAvatarRoot().gameObject;
-
             var dressers = gameObject.GetComponentsInChildren<AutoDresser>(true).Where(c => c.enabled).ToArray();
-            var parameters = dressers.DresserToCostumes(out Transform avatarRoot, null, new Preset[]{}, dresser).Select(c => c.parametersPerMenu).ToArray();
-
+            
+            // create a parameter list to disable other dressers
+            var disableParameters = new ParametersPerMenu();
+            disableParameters.objects = dressers.Where(d => d != dresser)  
+                .Select(d => d.gameObject)  
+                .Select(go => new ObjectToggler { obj = go, value = false })  
+                .ToArray();
+            
+            // get the parameters of the current dresser
+            var parameters = new[] { dresser }.DresserToCostumes(out Transform avatarRoot, null, new Preset[]{}, dresser)
+                .Select(c => c.parametersPerMenu)
+                .ToArray();
+            
+            // merge parameters: disable other dressers first, then apply the current dresser's effect
+            if(parameters.Length > 0)
+            {
+                parameters[0].objects = parameters[0].objects.Union(disableParameters.objects).ToArray();
+            }
+            
             StartPreview(parameters, 0);
         }
 

--- a/Editor/VersionChecker.cs
+++ b/Editor/VersionChecker.cs
@@ -20,7 +20,7 @@ namespace jp.lilxyzw.lilycalinventory
         {
             if(label == null)
             {
-                if(instance.latest > instance.current)
+                if (instance.latest != null && instance.current != null && instance.latest > instance.current)
                 {
                     // 更新がある場合は最新バージョンも合わせて表示、赤字で強調
                     label = new GUIContent($"{ConstantValues.TOOL_NAME} {instance.current} => {instance.latest}");
@@ -90,6 +90,10 @@ namespace jp.lilxyzw.lilycalinventory
                     instance.latest = new SemVerParser("0.0.0");
                     throw e;
                 }
+            }
+            else
+            {
+                instance.latest = new SemVerParser("0.0.0");
             }
         }
 


### PR DESCRIPTION
# Issue Fixed
Fixed an issue where BlendShape Modifiers and other effects from non-previewed AutoDressers were incorrectly applied during preview.

# Changes Made
Modified the `StartPreview(AutoDresser)` method to only process parameters from the currently selected AutoDresser.

# Testing
Verified:
1. When previewing a single AutoDresser, parameters from other AutoDressers are not applied
2. When previewing a single AutoDresser, its GameObject is enabled while other AutoDresser GameObjects are disabled