### PR TITLE
Update Modifier.AutoFixMeshSettings.cs

### DIFF
--- a/Editor/Processor/Modifier.AutoFixMeshSettings.cs
+++ b/Editor/Processor/Modifier.AutoFixMeshSettings.cs
@@ -42,7 +42,10 @@ namespace jp.lilxyzw.lilycalinventory
                         s.skinnedMotionVectors = settings.meshSettings.skinnedMotionVectors;
                         if(!s.gameObject.GetComponent<Cloth>())
                         {
-                            s.rootBone = rootBone;
+                            if(s.rootBone != null)
+                            {
+                                s.rootBone = rootBone;
+                            }
                             s.localBounds = bounds;
                         }
                     }


### PR DESCRIPTION
Fixes #167 
Fixes #168 

RootBoneが設定されていないスキンメッシュに対しては、RootBoneの上書きを行わないように処理を修正しました。 (RootBoneがない、かつBlendshapeが存在するメッシュ、という存在は許容されるものであるようです)